### PR TITLE
Update to Spring 3.2,

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,7 @@ target/**
 *.project
 **/native-libs
 
+mabeaulieu-local-test/**
+
 # For java version control on Ubuntu with jenv
 .java-version

--- a/limq-marker-entities/src/main/java/com/limq/model/ImprovisationTeam.java
+++ b/limq-marker-entities/src/main/java/com/limq/model/ImprovisationTeam.java
@@ -1,14 +1,7 @@
 package com.limq.model;
 
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToMany;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
+
 import java.util.List;
 import java.util.Objects;
 
@@ -20,7 +13,10 @@ public class ImprovisationTeam {
     private String id;
 
     @ManyToMany(cascade = CascadeType.REMOVE, fetch = FetchType.LAZY)
-    @JoinColumn(name = "improvisation_team_id", updatable = false)
+    @JoinTable(
+        name = "ImprovisationTeam_ImprovisationPlayer",
+        joinColumns = {@JoinColumn(name = "improvisation_team_id")},
+        inverseJoinColumns = {@JoinColumn(name = "person_id")})
     private List<Person> improvisationPlayers;
 
     public String getId() {

--- a/limq-marker-entities/src/main/java/com/limq/model/Match.java
+++ b/limq-marker-entities/src/main/java/com/limq/model/Match.java
@@ -1,18 +1,8 @@
 package com.limq.model;
 
 
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToMany;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
+
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Objects;
@@ -25,12 +15,18 @@ public class Match {
     private String id;
     @Column(name = "date")
     private LocalDateTime date;
+
     @ManyToMany(cascade = CascadeType.REMOVE, fetch = FetchType.LAZY)
-    @JoinColumn(name = "improvisation_id", updatable = false)
+    @JoinTable(
+        name = "Match_Host",
+        joinColumns = {@JoinColumn(name = "improvisation_id")},
+        inverseJoinColumns = {@JoinColumn(name = "person_id")})
     private List<Person> hosts;
     @ManyToMany(cascade = CascadeType.REMOVE, fetch = FetchType.LAZY)
-    @JoinColumn(name = "improvisation_id", updatable = false)
-    private List<Person> judges;
+    @JoinTable(
+        name = "Match_Judge",
+        joinColumns = {@JoinColumn(name = "improvisation_team_id")},
+        inverseJoinColumns = {@JoinColumn(name = "person_id")})    private List<Person> judges;
     @ManyToOne(cascade = CascadeType.REMOVE, fetch = FetchType.LAZY)
     @JoinColumn(name = "referee_id", updatable = false)
     private Person referee;

--- a/limq-marker-entities/src/main/java/com/limq/model/Team.java
+++ b/limq-marker-entities/src/main/java/com/limq/model/Team.java
@@ -1,15 +1,7 @@
 package com.limq.model;
 
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToMany;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
+
 import java.util.List;
 import java.util.Objects;
 
@@ -24,7 +16,10 @@ public class Team {
     @Column(name = "name")
     private String name;
     @ManyToMany(cascade = CascadeType.REMOVE, fetch = FetchType.LAZY)
-    @JoinColumn(name = "team_id", updatable = true)
+    @JoinTable(
+        name = "Team_Member",
+        joinColumns = {@JoinColumn(name = "team_id")},
+        inverseJoinColumns = {@JoinColumn(name = "person_id")})
     private List<Person> members;
 
     public String getId() {

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <!-- Maven Plugins -->
         <surefire.plugin.version>3.1.2</surefire.plugin.version>
 
-        <spring.boot.version>3.1.5</spring.boot.version>
+        <spring.boot.version>3.2.1</spring.boot.version>
         <flyway.version>9.22.3</flyway.version>
 
         <!-- Unit Test Libraries -->
@@ -37,7 +37,7 @@
             <dependency>
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-framework-bom</artifactId>
-                <version>6.0.11</version>
+                <version>6.1.2</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -105,9 +105,6 @@
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.11.0</version>
-                    <configuration>
-                        <parameters>true</parameters>
-                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -105,6 +105,9 @@
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.11.0</version>
+                    <configuration>
+                        <parameters>true</parameters>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Update to Spring 3.2 (there is something in Spring 3.2 which will help with having UUID on our REST for local testing)

- In 3.2, Spring was complaining about `ManyToMany` using `JoinColumn`, and instead required `JoinTable`, so I made the change. 
  - Also, it does require the relation to be either entirely read-only (e.g. both not insertable and not updatable), or updatable. In our context, I believe it did make sense to those infos after the creation of either entities so I turned them in something updatable.
- [EDIT 2024-01-21: Removed] To use UUID in Swagger API, we need the `parameters` configuration in maven compiler plugin.

## Next PR

I do need that one to test out the API in local, I ran into issues when trying to insert Impro teams.